### PR TITLE
Handle "confirm logout" dialog closure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+proton-vpn-gtk-app (4.0.0) unstable; urgency=medium
+
+  * Stable release
+
+ -- Alexandru Cheltuitor <alexandru.cheltuitor@proton.ch>  Tue, 10 Oct 2023 12:00:00 +0100
+
 proton-vpn-gtk-app (4.0.0~b2) unstable; urgency=medium
 
   * Add account data to settings window

--- a/proton/vpn/app/gtk/assets/release_notes.md
+++ b/proton/vpn/app/gtk/assets/release_notes.md
@@ -1,3 +1,6 @@
+## 4.0.0
+- The new Proton VPN Linux client is officially out of beta. This release completes our journey from alpha to beta and delivers a stable version, ensuring a refined and polished user experience.
+
 ## 4.0.0-b2
 - We have added account information to the settings window. You can now quickly access your plan and manage your account.
 - Fixed authentication issue causing pop-up with invalid session.

--- a/proton/vpn/app/gtk/widgets/headerbar/menu/menu.py
+++ b/proton/vpn/app/gtk/widgets/headerbar/menu/menu.py
@@ -174,7 +174,7 @@ class Menu(Gio.Menu):  # pylint: disable=too-many-instance-attributes
             logout_dialog.destroy()
 
             confirm_logout = response == Gtk.ResponseType.YES
-            self.logout_enabled = response == Gtk.ResponseType.NO
+            self.logout_enabled = response in (Gtk.ResponseType.NO, Gtk.ResponseType.DELETE_EVENT)
 
         if confirm_logout:
             logger.info("Yes", category="ui", subcategory="dialog", event="logout")

--- a/rpmbuild/SPECS/package.spec
+++ b/rpmbuild/SPECS/package.spec
@@ -1,9 +1,9 @@
 %define unmangled_name proton-vpn-gtk-app
 %define version 4.0.0
-%define upstream_version 4.0.0b2
+%define upstream_version 4.0.0
 %define logo_filename proton-vpn-logo.svg
 %define desktop_entry_filename protonvpn-app.desktop
-%define release 0.18.b2
+%define release 1
 
 Prefix: %{_prefix}
 Name: %{unmangled_name}
@@ -69,6 +69,9 @@ python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUI
 %defattr(-,root,root)
 
 %changelog
+* Tue Oct 10 2023 Alexandru Cheltuitor <alexandru.cheltuitor@proton.ch> 4.0.0-1
+- Stable release
+
 * Fri Sep 15 2023 Alexandru Cheltuitor <alexandru.cheltuitor@proton.ch> 4.0.0-0.18.b2
 - Add account data to settings window
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="proton-vpn-gtk-app",
-    version="4.0.0b2",
+    version="4.0.0",
     description="Proton VPN GTK app",
     author="Proton AG",
     author_email="contact@protonmail.com",


### PR DESCRIPTION
When connected to VPN and a logout is attempted, you will receive a prompt asking you to confirm, as you will be disconnected from the VPN. 

Once the logout button is clicked, it is disabled, and in the case that you answer No (that you do not wish to log out) to the prompt, it closes and the button is enabled. However, if you close the prompt (using the X in the top-right), the button is not re-enabled, as the code does not check for `Gtk.ResponseType.DELETE_EVENT`.