### PR TITLE
Allows `protonvpn-app` to start minimized

### DIFF
--- a/proton/vpn/app/gtk/widgets/main/main_window.py
+++ b/proton/vpn/app/gtk/widgets/main/main_window.py
@@ -162,7 +162,7 @@ class MainWindow(Gtk.ApplicationWindow):
         )
 
     def quit(self):
-        """Closes the main window, which quites the app."""
+        """Closes the main window, which quits the app."""
         if self._close_window_handler_id:
             self.disconnect(self._close_window_handler_id)
 


### PR DESCRIPTION
Addresses: https://protonmail.uservoice.com/forums/932836-proton-vpn/suggestions/45290605-start-protonvpn-minimized-in-tray-linux

Adds two command line options to `protonvpn-app`:
* `--start-minimized`
* `--version`

```shell
protonvpn-app --help
Usage:
  protonvpn-app [OPTION…]

Help Options:
  -h, --help                 Show help options
  --help-all                 Show all help options
  --help-gapplication        Show GApplication options
  --help-gtk                 Show GTK+ Options

Application Options:
  --start-minimized          Start minimized in the system tray
  -v, --version              Display the application's version
  --display=DISPLAY          X display to use
```

Example output with `--version`
```shell
protonvpn-app --version
4.3.2
```
```shell
echo "Exit status: $?"
Exit status: 0
```

```shell
protonvpn-app -v
4.3.2
```

To start Proton VPN minimized:
```shell
protonvpn-app --start-minimized
```
