### PR TITLE
Handle no seat (remote desktop sessions)

### DIFF
--- a/proton/vpn/app/gtk/services/reconnector/session_monitor.py
+++ b/proton/vpn/app/gtk/services/reconnector/session_monitor.py
@@ -95,11 +95,15 @@ class SessionMonitor:
             PROPERTIES_INTERFACE
         )
 
-        # There should always be session for a seat. If there is no seat then
+        # There should always be a seat, and a session for a seat. If there is no seat then
         # it means that the user is not directly controlling the machine,
         # but rather controlloing it via ssh or some other indirect
         # type of control.
-        seat_properties = seat_auto_properties_proxy.GetAll(SEAT_INTERFACE)
+        try:
+            seat_properties = seat_auto_properties_proxy.GetAll(SEAT_INTERFACE)
+        except dbus.exceptions.DBusException as dbus_exc:
+            raise SeatNotFoundError(dbus_exc.get_dbus_message())
+
         active_sessions = seat_properties.get("ActiveSession", [])
 
         if not active_sessions:
@@ -112,3 +116,6 @@ class SessionMonitor:
         This is mainly used for testing purposes.
         """
         self._signal_receiver = new_object
+
+class SeatNotFoundError(Exception):
+    """Exception raised when the session monitor is not able to find the current seat."""


### PR DESCRIPTION
If the user is trying to open the application while on a session with no seat (e.g. remote desktop), the session monitor will fail retrieving the `/org/freedesktop/login1/seat/auto` object (because of an unknown object exception from D-Bus) and this exception is not caught. This way, exception handler shows unknown error with no information.

This PR implements an exception for this (seemed cleaner this way than checking for `dbus.exceptions.DBusException` in exception handler directly), and implements logic to the exception handler to catch it and provide the user with information regarding the exception (and a workaround with manual connection).

--

This can be reproduced by having a VM with VNC server, and then connecting to it with a VNC client and starting the Proton VPN client from the same session.

![image](https://github.com/user-attachments/assets/fda88aa5-8611-45b9-aa00-db0992cef09b)
