### PR TITLE
feat: add --connect <SERVER> cli arg

### DIFF
--- a/proton/vpn/app/gtk/app.py
+++ b/proton/vpn/app/gtk/app.py
@@ -119,6 +119,13 @@ class App(Gtk.Application):
         if options.contains("start-minimized"):
             self._start_minimized_from_cli = True
 
+        if options.contains("connect"):
+            value = options.lookup_value("connect", GLib.VariantType("s"))
+            if value is None:
+                print("Error: Missing argument for --connect/-c")
+                return 1
+            self._controller.set_connect_at_app_startup_override(value.get_string().upper())
+
         return -1
 
     @property
@@ -224,7 +231,16 @@ class App(Gtk.Application):
             or self._controller.get_app_configuration().start_app_minimized
 
     def add_options(self):
-        """Adds the --start-minimized and --version command line options"""
+        """Adds the --connect, --start-minimized and --version command line options"""
+        self.add_main_option(
+            "connect",
+            ord('c'),
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            "Automatically connect to the specified server (e.g. DE or DE#1)",
+            "SERVER_NAME"
+        )
+
         self.add_main_option(
             "start-minimized",
             0,

--- a/proton/vpn/app/gtk/controller.py
+++ b/proton/vpn/app/gtk/controller.py
@@ -178,7 +178,7 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
             category="app", subcategory="startup", event="startup_actions"
         )
         if self.user_logged_in:
-            connect_to = self._connect_at_app_startup_override or self.get_app_configuration().connect_at_app_startup
+            connect_to = self._connect_at_app_startup
             if connect_to:
                 self.autoconnect(connect_to)
 
@@ -187,7 +187,7 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
             This method is intended to be called at app startup.
         """
         if connect_to is None:
-            connect_to = self.get_app_configuration().connect_at_app_startup
+            connect_to = self._connect_at_app_startup
 
         # Temporary hack for parsing. Should be improved
         if connect_to == "FASTEST":
@@ -564,6 +564,11 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
     def set_connect_at_app_startup_override(self, override: Optional[str]):
         """Sets an override for the connect_at_app_startup configuration value."""
         self._connect_at_app_startup_override = override
+
+    @property
+    def _connect_at_app_startup(self) -> Optional[str]:
+        """Returns the current connect_at_app_startup value."""
+        return self._connect_at_app_startup_override or self.get_app_configuration().connect_at_app_startup
 
     def set_server_list_updated_callback(self, callback: Callable[[], None]):
         """Sets the callback that is called when the server list is updated."""

--- a/proton/vpn/app/gtk/controller.py
+++ b/proton/vpn/app/gtk/controller.py
@@ -96,6 +96,7 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
         self.reconnector = vpn_reconnector
 
         self._app_config = app_config
+        self._connect_at_app_startup_override = None
         self._cache_handler = cache_handler or CacheHandler(APP_CONFIG)
         self._settings_watchers = SettingsWatchers()
 
@@ -176,23 +177,23 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
             "Running startup actions",
             category="app", subcategory="startup", event="startup_actions"
         )
-        if (
-            self.user_logged_in
-            and self.get_app_configuration().connect_at_app_startup
-        ):
-            self.autoconnect()
+        if self.user_logged_in:
+            connect_to = self._connect_at_app_startup_override or self.get_app_configuration().connect_at_app_startup
+            if connect_to:
+                self.autoconnect(connect_to)
 
-    def autoconnect(self) -> Future:
+    def autoconnect(self, connect_to: str = None) -> Future:
         """Connects to a server from app configuration.
             This method is intended to be called at app startup.
         """
-        connect_at_app_startup = self.get_app_configuration().connect_at_app_startup
+        if connect_to is None:
+            connect_to = self.get_app_configuration().connect_at_app_startup
 
         # Temporary hack for parsing. Should be improved
-        if connect_at_app_startup == "FASTEST":
+        if connect_to == "FASTEST":
             return self.connect_to_fastest_server()
 
-        return self._connect_to(connect_at_app_startup)
+        return self._connect_to(connect_to)
 
     def connect_from_tray(self, connect_to: str) -> Future:
         """Connect to servers from tray."""
@@ -559,6 +560,10 @@ class Controller:  # pylint: disable=too-many-public-methods, too-many-instance-
 
         future = self.executor.submit(disable)
         future.add_done_callback(lambda f: GLib.idle_add(f.result))
+
+    def set_connect_at_app_startup_override(self, override: Optional[str]):
+        """Sets an override for the connect_at_app_startup configuration value."""
+        self._connect_at_app_startup_override = override
 
     def set_server_list_updated_callback(self, callback: Callable[[], None]):
         """Sets the callback that is called when the server list is updated."""


### PR DESCRIPTION
This allows you to override the Auto Connect option via a cli flag to immediately connect to the specified server.

Using this, you can can for example create different desktop shortcuts / keybinds that directly connect to a desired country