### PR TITLE
fix: Gracefully fail if without session bus

### DIFF
--- a/proton/vpn/app/gtk/services/reconnector/session_monitor.py
+++ b/proton/vpn/app/gtk/services/reconnector/session_monitor.py
@@ -58,7 +58,12 @@ class SessionMonitor:
             self._bus = SystemBus()
 
         if not self._session_object_path:
-            self._setup()
+            try:
+                self._setup()
+            except Exception:
+                # logind is inaccessible (e.g. AppArmor in strict snap confinement).
+                # Session-unlock reconnection won't work, but everything else is fine.
+                return
 
         self._signal_receiver = self._bus.add_signal_receiver(
             handler_function=self.session_unlocked_callback,
@@ -78,7 +83,12 @@ class SessionMonitor:
     def is_session_unlocked(self):
         """Returns True if the user session is unlocked or False otherwise."""
         if not self._session_object_path:
-            self._setup()
+            try:
+                self._setup()
+            except Exception:
+                # logind is inaccessible; assume session is unlocked so reconnection
+                # can proceed when network comes up.
+                return True
 
         active_session = self._bus.get_object(BUS_NAME, self._session_object_path)
         active_session_properties = dbus.Interface(active_session, PROPERTIES_INTERFACE)

--- a/proton/vpn/app/gtk/services/reconnector/session_monitor.py
+++ b/proton/vpn/app/gtk/services/reconnector/session_monitor.py
@@ -60,7 +60,7 @@ class SessionMonitor:
         if not self._session_object_path:
             try:
                 self._setup()
-            except Exception:
+            except dbus.exceptions.DBusException:
                 # logind is inaccessible (e.g. AppArmor in strict snap confinement).
                 # Session-unlock reconnection won't work, but everything else is fine.
                 return
@@ -85,7 +85,7 @@ class SessionMonitor:
         if not self._session_object_path:
             try:
                 self._setup()
-            except Exception:
+            except dbus.exceptions.DBusException:
                 # logind is inaccessible; assume session is unlocked so reconnection
                 # can proceed when network comes up.
                 return True

--- a/tests/unit/services/reconnector/test_session_monitor.py
+++ b/tests/unit/services/reconnector/test_session_monitor.py
@@ -68,6 +68,30 @@ def test_enable_raises_runtime_error_if_there_is_not_an_active_session(dbus_mock
         session_monitor.enable()
 
 
+@patch("proton.vpn.app.gtk.services.reconnector.session_monitor.dbus")
+def test_enable_ignores_dbus_exception_if_logind_is_inaccessible(dbus_mock):
+    bus_mock = Mock()
+    callback_mock = Mock()
+    session_monitor = SessionMonitor(bus_mock)
+    session_monitor.session_unlocked_callback = callback_mock
+
+    bus_mock.get_object.side_effect = dbus_mock.exceptions.DBusException("access denied")
+
+    session_monitor.enable()
+
+    bus_mock.add_signal_receiver.assert_not_called()
+
+
+@patch("proton.vpn.app.gtk.services.reconnector.session_monitor.dbus")
+def test_is_session_unlocked_returns_true_if_logind_is_inaccessible(dbus_mock):
+    bus_mock = Mock()
+    session_monitor = SessionMonitor(bus_mock)
+
+    bus_mock.get_object.side_effect = dbus_mock.exceptions.DBusException("access denied")
+
+    assert session_monitor.is_session_unlocked is True
+
+
 def test_disable_unhooks_login1_signal():
     bus_mock = Mock()
     signal_receiver_mock = Mock()


### PR DESCRIPTION
Gracefully fail to for login observe if we don't have access to that interface. Such as when the login-session-observe isn't connected in the snap.