### PR TITLE
fix: keep tray menu state aligned with window visibility

### DIFF
--- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
@@ -28,7 +28,7 @@ from proton.vpn.connection import states
 from proton.vpn.app.gtk.assets.icons import ICONS_PATH
 from proton.vpn.app.gtk.controller import Controller
 from proton.vpn.app.gtk.widgets.main.main_window import MainWindow
-from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon, SNW_BUS_NAME
+from proton.vpn.app.gtk.widgets.main.tray_icon import MenuType, TrayIcon, SNW_BUS_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +240,11 @@ class TrayIndicator:
         """Sets the main window for the tray indicator."""
         self._main_window = main_window
         self._build_menu()
+        self._main_window.connect("show", self._on_main_window_visibility_changed)
+        self._main_window.connect("hide", self._on_main_window_visibility_changed)
+        self._main_window.connect(
+            "notify::visible", self._on_main_window_visibility_changed
+        )
 
         self._main_window.main_widget.login_widget.connect(
             "user-logged-in", self._on_user_logged_in
@@ -269,17 +274,33 @@ class TrayIndicator:
         self._tray.menu_items.clear()
 
         self._setup_connection_handler_entries()
-        self._tray.add_menu_separator()
+        self._append_separator_if_needed()
 
         if self._controller.user_logged_in:
             self.display_pinned_servers = True
             self._setup_pinned_server_entries()
 
+        self._append_separator_if_needed()
         self._setup_main_window_visibility_toggle_entry()
-        self._tray.add_menu_separator()
+        self._append_separator_if_needed()
         self._setup_quit_entry()
 
         self._tray.update_menu()
+
+    def _append_separator_if_needed(self):
+        if not self._tray.menu_items:
+            return
+
+        if self._tray.menu_items[-1].type == MenuType.SEPARATOR:
+            return
+
+        if not any(
+            item.type == MenuType.ITEM and item.visible
+            for item in self._tray.menu_items
+        ):
+            return
+
+        self._tray.add_menu_separator()
 
     def _setup_pinned_server_entries(self):
         tray_pinned_servers = self._controller.get_app_configuration().tray_pinned_servers
@@ -292,17 +313,19 @@ class TrayIndicator:
                 label=f"{servername}",
                 callback=lambda server=servername: self._on_connect_to_pinned_entry_clicked(server))
 
-        self._tray.add_menu_separator()
-
     def _setup_connection_handler_entries(self):
-        self._tray.add_menu_item("Quick Connect",
-                                 self._on_connect_entry_clicked,
-                                 self.enable_connect_entry,
-                                 self.display_connect_entry)
-        self._tray.add_menu_item("Disconnect",
-                                 self._on_disconnect_entry_clicked,
-                                 self.enable_disconnect_entry,
-                                 self.display_disconnect_entry)
+        if self.display_connect_entry:
+            self._tray.add_menu_item(
+                "Quick Connect",
+                self._on_connect_entry_clicked,
+                self.enable_connect_entry,
+            )
+        if self.display_disconnect_entry:
+            self._tray.add_menu_item(
+                "Disconnect",
+                self._on_disconnect_entry_clicked,
+                self.enable_disconnect_entry,
+            )
 
     def _setup_main_window_visibility_toggle_entry(self):
         toggle_label = "Show" if not self._main_window.get_visible() else "Hide"
@@ -326,6 +349,9 @@ class TrayIndicator:
         else:
             self._main_window.set_visible(True)
             self._main_window.present()
+        self._update()
+
+    def _on_main_window_visibility_changed(self, *_):
         self._update()
 
     def _on_exit_app_menu_entry_clicked(self, *_):

--- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
@@ -28,7 +28,7 @@ from proton.vpn.connection import states
 from proton.vpn.app.gtk.assets.icons import ICONS_PATH
 from proton.vpn.app.gtk.controller import Controller
 from proton.vpn.app.gtk.widgets.main.main_window import MainWindow
-from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon
+from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon, SNW_BUS_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,12 @@ class TrayIndicator:
 
         if self._tray is None:
             self._tray = TrayIcon()
-            self._tray.setup()
+            try:
+                self._tray.setup()
+            except Exception as exc:
+                raise TrayIndicatorNotSupported(
+                    f"Failed to set up system tray: {exc}"
+                ) from exc
 
         self.status_update(self._controller.current_connection_status)
         self._controller.register_connection_status_subscriber(self)
@@ -169,12 +174,67 @@ class TrayIndicator:
         # If gnome shell is not running then it's another DE and
         # we assume tray works by default.
         if self._gnome_tray_detection.is_gnome_shell_running():
-            self._app_indicator_available |= self._gnome_tray_detection.is_extension_active()
+            gnome_extensions = self._gnome_tray_detection._gnome_shell_list_extensions()
+            if gnome_extensions is None:
+                self._app_indicator_available = self._is_status_notifier_watcher_available()
+            else:
+                ubuntu_extension = gnome_extensions.get(UBUNTU_INDICATOR_EXTENSION)
+                default_extension = gnome_extensions.get(DEFAULT_INDICATOR_EXTENSION)
+
+                enable_for_ubuntu = (
+                    ubuntu_extension and ubuntu_extension.get("state") == ACTIVE_STATE
+                )
+                enable_for_default = (
+                    default_extension
+                    and not self._disabled_user_extension()
+                    and default_extension.get("state") == ACTIVE_STATE
+                )
+
+                if enable_for_ubuntu or enable_for_default:
+                    self._app_indicator_available = True
         else:
             self._app_indicator_available = True
             logger.warning("Tray icon enabled on an unsupported desktop environment")
 
         return self._app_indicator_available
+
+    def _is_status_notifier_watcher_available(self, timeout_ms: int = 300) -> bool:
+        """Return True if the StatusNotifierWatcher D-Bus service is running."""
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            dbus_proxy = Gio.DBusProxy.new_sync(
+                bus,
+                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
+                None,
+                "org.freedesktop.DBus",
+                "/org/freedesktop/DBus",
+                "org.freedesktop.DBus",
+                None,
+            )
+            (has_owner,) = dbus_proxy.call_sync(
+                "NameHasOwner",
+                GLib.Variant("(s)", (SNW_BUS_NAME,)),
+                Gio.DBusCallFlags.NONE,
+                timeout_ms,
+                None,
+            ).unpack()
+            return bool(has_owner)
+        except GLib.Error:
+            logger.exception("Unable to check for StatusNotifierWatcher")
+            return False
+
+    def _disabled_user_extension(self) -> Optional[bool]:
+        source = Gio.SettingsSchemaSource.get_default()
+        if not source:
+            return None
+
+        schema = source.lookup("org.gnome.shell", True)
+        if not schema:
+            return None
+
+        settings = Gio.Settings.new_full(schema, None, None)
+        disabled_extensions = settings.get_strv("disabled-extensions")
+        return DEFAULT_INDICATOR_EXTENSION in disabled_extensions
 
     def _set_main_window(self, main_window: MainWindow):
         """Sets the main window for the tray indicator."""


### PR DESCRIPTION
Use:

- `0003-clean-up-tray-menu-state.patch`

Scope:

- avoid extra separators
- omit hidden connect/disconnect entries from the exported menu
- keep `Show` / `Hide` aligned with actual window visibility