### PR TITLE
fix: re-register tray item when tray host restarts

### DIFF
--- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
@@ -238,6 +238,7 @@ class _StatusNotifierItem(dbus.service.Object):
     def __init__(self, tray_icon, bus, object_path):
         self.tray = tray_icon
         self.bus = bus
+        self._watcher_owner = None
 
         # Generate unique bus name
         self.bus_name_str = f"org.kde.StatusNotifierItem-{tray_icon.app_id}-{os.getpid()}"
@@ -248,8 +249,30 @@ class _StatusNotifierItem(dbus.service.Object):
         # Create DBusMenu
         self.menu = _DBusMenuService(bus, tray_icon.menu_items)
 
+        # Re-register if the tray host disappears and comes back.
+        self._subscribe_watcher_changes()
         # Register with watcher
         self._register_to_watcher()
+
+    def _subscribe_watcher_changes(self):
+        self.bus.add_signal_receiver(
+            self._on_name_owner_changed,
+            signal_name="NameOwnerChanged",
+            dbus_interface="org.freedesktop.DBus",
+            bus_name="org.freedesktop.DBus",
+            path="/org/freedesktop/DBus",
+            arg0=SNW_BUS_NAME,
+        )
+
+    def _on_name_owner_changed(self, name, old_owner, new_owner):
+        if name != SNW_BUS_NAME:
+            return
+
+        if new_owner and new_owner != self._watcher_owner:
+            self._watcher_owner = str(new_owner)
+            self._register_to_watcher()
+        elif not new_owner:
+            self._watcher_owner = None
 
     def _register_to_watcher(self):
         """Register with StatusNotifierWatcher"""
@@ -259,6 +282,7 @@ class _StatusNotifierItem(dbus.service.Object):
                 self.bus_name_str,
                 dbus_interface=SNW_INTERFACE
             )
+            self._watcher_owner = str(self.bus.get_name_owner(SNW_BUS_NAME))
         except dbus.exceptions.DBusException:
             # Silent fail, will still work on some DEs,
             # see https://specifications.freedesktop.org/status-notifier-item-spec/status-notifier-item-spec-latest.html#registration  # pylint: disable=line-too-long # noqa: E501

--- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
@@ -28,7 +28,7 @@ from proton.vpn.connection import states
 from proton.vpn.app.gtk.assets.icons import ICONS_PATH
 from proton.vpn.app.gtk.controller import Controller
 from proton.vpn.app.gtk.widgets.main.main_window import MainWindow
-from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon
+from proton.vpn.app.gtk.widgets.main.tray_icon import TrayIcon, SNW_BUS_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,12 @@ class TrayIndicator:
 
         if self._tray is None:
             self._tray = TrayIcon()
-            self._tray.setup()
+            try:
+                self._tray.setup()
+            except Exception as exc:
+                raise TrayIndicatorNotSupported(
+                    f"Failed to set up system tray: {exc}"
+                ) from exc
 
         self.status_update(self._controller.current_connection_status)
         self._controller.register_connection_status_subscriber(self)
@@ -169,12 +174,67 @@ class TrayIndicator:
         # If gnome shell is not running then it's another DE and
         # we assume tray works by default.
         if self._gnome_tray_detection.is_gnome_shell_running():
-            self._app_indicator_available |= self._gnome_tray_detection.is_extension_active()
+            gnome_extensions = self._gnome_tray_detection._gnome_shell_list_extensions()
+            if gnome_extensions is None:
+                self._app_indicator_available = self._is_status_notifier_watcher_available()
+            else:
+                ubuntu_extension = gnome_extensions.get(UBUNTU_INDICATOR_EXTENSION)
+                default_extension = gnome_extensions.get(DEFAULT_INDICATOR_EXTENSION)
+
+                enable_for_ubuntu = (
+                    ubuntu_extension and ubuntu_extension.get("state") == ACTIVE_STATE
+                )
+                enable_for_default = (
+                    default_extension
+                    and not self._disabled_user_extension()
+                    and default_extension.get("state") == ACTIVE_STATE
+                )
+
+                if enable_for_ubuntu or enable_for_default:
+                    self._app_indicator_available = True
         else:
             self._app_indicator_available = True
             logger.warning("Tray icon enabled on an unsupported desktop environment")
 
         return self._app_indicator_available
+
+    def _is_status_notifier_watcher_available(self, timeout_ms: int = 300) -> bool:
+        """Return True if the StatusNotifierWatcher D-Bus service is running."""
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            dbus_proxy = Gio.DBusProxy.new_sync(
+                bus,
+                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
+                None,
+                "org.freedesktop.DBus",
+                "/org/freedesktop/DBus",
+                "org.freedesktop.DBus",
+                None,
+            )
+            (has_owner,) = dbus_proxy.call_sync(
+                "NameHasOwner",
+                GLib.Variant("(s)", (SNW_BUS_NAME,)),
+                Gio.DBusCallFlags.NONE,
+                timeout_ms,
+                None,
+            ).unpack()
+            return bool(has_owner)
+        except GLib.Error:
+            logger.exception("Unable to check for StatusNotifierWatcher")
+            return False
+
+    def _disabled_user_extension(self) -> Optional[bool]:
+        source = Gio.SettingsSchemaSource.get_default()
+        if not source:
+            return None
+
+        schema = source.lookup("org.gnome.shell", True)
+        if not schema:
+            return None
+
+        settings = Gio.Settings.new_full(schema, None, None)
+        disabled_extensions = settings.get_strv("disabled-extensions")
+        return DEFAULT_INDICATOR_EXTENSION in disabled_extensions
 
     def _set_main_window(self, main_window: MainWindow):
         """Sets the main window for the tray indicator."""


### PR DESCRIPTION
## Summary

  This fixes a tray recovery issue on desktop environments that expose a
  `StatusNotifierWatcher` and can restart the tray host independently of the app.

  In that situation, ProtonVPN registers its tray item successfully at startup,
  but if the tray host disappears and comes back later, the tray icon is lost
  until the app is restarted. This is observed in NixOS using hyprpanel.

  ## Root cause

  `TrayIcon` only registers with `org.kde.StatusNotifierWatcher` once during
  startup.

  When the tray host restarts, the watcher bus name disappears and comes back
  with a new owner, but ProtonVPN never re-registers its
  `StatusNotifierItem`.

  ## Fix

  - subscribe to `org.freedesktop.DBus.NameOwnerChanged`
  - watch `org.kde.StatusNotifierWatcher`
  - when the watcher gets a new owner, call `RegisterStatusNotifierItem(...)`
    again
  - clear the cached owner when the watcher disappears

  ## Why this matters

  This makes the tray icon recover automatically after panel restarts without
  requiring the ProtonVPN GUI process to be restarted.

  It is especially relevant on Wayland compositors / panels where the tray host
  can restart independently from client apps.

  ## Validation

  Tested by:
  - starting ProtonVPN normally
  - restarting the tray host / panel
  - confirming the tray item is re-registered when the watcher comes back