### PR TITLE
fix: early access widget crashes on None subprocess result

### DIFF
--- a/proton/vpn/app/gtk/widgets/headerbar/menu/settings/early_access.py
+++ b/proton/vpn/app/gtk/widgets/headerbar/menu/settings/early_access.py
@@ -274,8 +274,13 @@ class EarlyAccessWidget(ToggleWidget):
             ).result()
 
         if self._command_failed(result):
+            stderr = (
+                result.stderr.decode('utf-8')
+                if result and hasattr(result, 'stderr') and result.stderr
+                else "No result"
+            )
             logger.warning(
-                f"Unable to list repo packages: {result.stderr.decode('utf-8')}",
+                f"Unable to list repo packages: {stderr}",
                 category="subprocess", subcategory="command", event="run"
             )
             return stable_repo_package_installed, beta_repo_package_installed
@@ -301,9 +306,19 @@ class EarlyAccessWidget(ToggleWidget):
             result = future.result()
 
             if self._command_failed(result):
+                stderr = (
+                    result.stderr.decode('utf8')
+                    if result and hasattr(result, 'stderr') and result.stderr
+                    else ""
+                )
+                stdout = (
+                    result.stdout.decode('utf8')
+                    if result and hasattr(result, 'stdout') and result.stdout
+                    else ""
+                )
                 logger.warning(
-                    f"Unable to fulfil command: \nstderr: {result.stderr.decode('utf8')}\n"
-                    f"stdout: {result.stdout.decode('utf8')}",
+                    f"Unable to fulfil command: \nstderr: {stderr}\n"
+                    f"stdout: {stdout}",
                     category="subprocess", subcategory="command", event="run"
                 )
                 self._restore_switch_to_previous_state()
@@ -342,4 +357,6 @@ class EarlyAccessWidget(ToggleWidget):
         GLib.idle_add(self.set_state, self.get_setting())
 
     def _command_failed(self, result) -> bool:
+        if result is None:
+            return True
         return result.returncode != 0

--- a/tests/unit/widgets/headerbar/menu/settings/test_early_access.py
+++ b/tests/unit/widgets/headerbar/menu/settings/test_early_access.py
@@ -175,3 +175,64 @@ class TestEarlyAccessWidget:
             callback(None, False, None)
 
             mock_distro_manager.build_update_command.assert_called_once_with(mock_distro_manager.beta_package_name, mock_distro_manager.stable_package_name)
+
+    def test_command_failed_returns_true_when_result_is_none(self):
+        """A None subprocess result should be treated as a failure instead of
+        raising AttributeError."""
+        with patch.object(ToggleWidget, '__init__', return_value=None):
+            widget = EarlyAccessWidget(Mock(), Mock(), Mock())
+            assert widget._command_failed(None) is True
+
+    def test_command_failed_delegates_to_returncode_when_result_is_not_none(self):
+        """A subprocess result with a non-zero return code is a failure."""
+        with patch.object(ToggleWidget, '__init__', return_value=None):
+            widget = EarlyAccessWidget(Mock(), Mock(), Mock())
+            result = Mock()
+            result.returncode = 1
+            assert widget._command_failed(result) is True
+
+            result.returncode = 0
+            assert widget._command_failed(result) is False
+
+    @patch.object(EarlyAccessWidget, "distro_manager")
+    def test_find_installed_repo_packages_does_not_crash_on_none_result(
+        self, mock_distro_manager
+    ):
+        """The package listing subprocess returning None (e.g. a mocked
+        controller) must not crash the settings widget."""
+        mock_controller = Mock()
+        mock_future = Mock()
+        mock_future.result.return_value = None
+        mock_controller.run_subprocess.return_value = mock_future
+
+        with patch.object(ToggleWidget, '__init__', return_value=None):
+            widget = EarlyAccessWidget(mock_controller, Mock(), Mock())
+
+        installed, _ = widget._find_installed_repo_packages()
+        assert installed is False
+
+    @patch.object(EarlyAccessWidget, "distro_manager")
+    def test_find_installed_repo_packages_detects_beta_package(
+        self, mock_distro_manager
+    ):
+        """A successful subprocess listing that contains the beta package
+        name is detected."""
+        mock_distro_manager.beta_package_name = "protonvpn-beta-release"
+        mock_distro_manager.stable_package_name = "protonvpn-stable-release"
+        mock_distro_manager.list_installed_packages_command = "rpm -qa"
+
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = b"protonvpn-beta-release\nprotonvpn-gtk-app\n"
+        mock_result.stderr = b""
+
+        mock_controller = Mock()
+        mock_future = Mock()
+        mock_future.result.return_value = mock_result
+        mock_controller.run_subprocess.return_value = mock_future
+
+        with patch.object(ToggleWidget, '__init__', return_value=None):
+            widget = EarlyAccessWidget(mock_controller, Mock(), Mock())
+
+        _, beta_installed = widget._find_installed_repo_packages()
+        assert beta_installed is True


### PR DESCRIPTION
## Summary

`EarlyAccessWidget` crashes with an `AttributeError` when the subprocess result is `None`:

```python
result = self._controller.run_subprocess(...).result()
if self._command_failed(result):   # result.returncode -> AttributeError
```

`_command_failed(None)` dereferences `None.returncode`, and both error paths unconditionally decode `result.stderr` / `result.stdout`.

This happens whenever `run_subprocess` returns a future that resolves to `None` — e.g. in tests or any mocked controller. In that case the widget raises instead of degrading gracefully.

## Changes

- `_command_failed(None)` now returns `True` (treated as a failure) instead of raising.
- Error paths guard the `stderr`/`stdout` decode with a `None` check and fall back to safe defaults.
- Added unit tests covering:
  - `_command_failed` with a `None` result and with a real returncode.
  - `_find_installed_repo_packages` not crashing on a `None` subprocess result.
  - Successful package listing still detecting the beta package.

## Testing

```
python3 -m pytest tests/unit -q --no-cov
487 passed
```

No functional change for the normal flow (subprocess always returns a `CompletedProcess` there).