### PR TITLE
Fixes system tray pinned servers bug that appears constantly on Plasma

### DIFF
--- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
@@ -376,6 +376,7 @@ class TrayIcon:  # pylint: disable=too-many-instance-attributes
         self.icon_desc = icon_desc
         self.status = "Active"
 
+        self.next_menu_id = 1
         self.menu_items = []
         self.on_left_click = None
         self.on_middle_click = None
@@ -425,7 +426,10 @@ class TrayIcon:  # pylint: disable=too-many-instance-attributes
 
     def _generate_menu_id(self):
         """Generate an used to identify the item in the menu."""
-        return len(self.menu_items) + 1 if len(self.menu_items) > 0 else 1
+        #Uses a generic incrementing counter over the previous length based approach to avoid issues with KDE Plasma
+        item_id = self.next_menu_id
+        self.next_menu_id += 1
+        return item_id
 
     def setup(self):
         """


### PR DESCRIPTION
When using pinned tray connections on KDE plasma (and probably other DEs) the pin list completely breaks appearing messed up, and functionally does not work (there is no way to connect to the UK from the tray the ghost slot is a button, but doesn't do anything).

<img width="89" height="222" alt="image" src="https://github.com/user-attachments/assets/3f6f37b8-a4ab-42af-9955-286b3a8679b5" />

I reported this 2 months ago and was told it was a known issue but I couldn't see it even listed in the issue tracker so here's a fix.

Its a bit odd as firstly, it presumably never occurs on GNOME otherwise it would've been patched already as it majorly breaks a feature, and secondly after some digging I found it only happens on start when start app minimised is True. Flipping it in .config and restarting the app completely fixes it.

Plasma appears to hate when dbus ids are reused and gets confused thus assigning values to the wrong place eg making "UK" a header tag rather than a button in the photo above. So instead each menu item gets a new incremental id and it seems to work fine. When starting the app maximised,  _build_menu() gets called multiple times rather than once when starting minimised, so would immediately cause plasma to get confused; although, the main issue is the id counting and the bug could also be caused by changing the pins list while running.

Patch applied:
<img width="89" height="222" alt="image" src="https://github.com/user-attachments/assets/2e1c926c-bfa7-40ca-9790-591a615a9729" />

Also everything here was written by a human ;)
