### PR TITLE
fix: don't start the controller in a redundant app instance (#187)

### DIFF
--- a/proton/vpn/app/gtk/__main__.py
+++ b/proton/vpn/app/gtk/__main__.py
@@ -22,14 +22,83 @@ along with ProtonVPN.  If not, see <https://www.gnu.org/licenses/>.
 
 import sys
 
+from gi.repository import Gio, GLib
+
 from proton.vpn.app.gtk.app import App
 from proton.vpn.app.gtk.controller import Controller
+from proton.vpn.app.gtk.util import APPLICATION_ID
 from proton.vpn.app.gtk.utils.exception_handler import ExceptionHandler
 from proton.vpn.app.gtk.utils.executor import AsyncExecutor
+
+# Timeouts, in milliseconds, for the two D-Bus calls used to hand over to an
+# already-running instance.
+NAME_HAS_OWNER_TIMEOUT_MS = 1000
+ACTIVATE_TIMEOUT_MS = 5000
+
+
+def activate_running_instance() -> bool:
+    """Hands over to an already-running app instance, if there is one.
+
+    Returns True if another instance was found and asked to present itself,
+    meaning this process should exit without starting anything.
+
+    Gtk.Application only discovers that it is redundant once run() registers it
+    on the session bus. By that point Controller.get() has already started the
+    asyncio executor and the Rust local agent's tokio runtime. run() then
+    returns immediately, and interpreter finalization races those still-running
+    threads: the tokio workers call into CPython while Py_Finalize() is freeing
+    the interpreter, which segfaults.
+
+    Checking for the well-known name first keeps a redundant instance from ever
+    starting that machinery.
+
+    Only the no-arguments case is short-circuited, so --version and
+    --start-minimized keep going through Gtk.Application's own option handling.
+    """
+    if len(sys.argv) > 1:
+        return False
+
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+
+        is_running = bus.call_sync(
+            "org.freedesktop.DBus",
+            "/org/freedesktop/DBus",
+            "org.freedesktop.DBus",
+            "NameHasOwner",
+            GLib.Variant("(s)", (APPLICATION_ID,)),
+            GLib.VariantType("(b)"),
+            Gio.DBusCallFlags.NONE,
+            NAME_HAS_OWNER_TIMEOUT_MS,
+            None,
+        ).unpack()[0]
+
+        if not is_running:
+            return False
+
+        bus.call_sync(
+            APPLICATION_ID,
+            "/" + APPLICATION_ID.replace(".", "/"),
+            "org.gtk.Application",
+            "Activate",
+            GLib.Variant("(a{sv})", ({},)),
+            None,
+            Gio.DBusCallFlags.NONE,
+            ACTIVATE_TIMEOUT_MS,
+            None,
+        )
+        return True
+    except GLib.Error:
+        # If the probe fails for any reason, fall through to the normal startup
+        # path and let Gtk.Application deal with it.
+        return False
 
 
 def main():
     """Runs the app."""
+    if activate_running_instance():
+        return
+
     with AsyncExecutor() as executor, ExceptionHandler() as exception_handler:
         controller = Controller.get(executor, exception_handler)
         sys.exit(App(controller).run(sys.argv))


### PR DESCRIPTION
Fixes #187, where launching `protonvpn-app` while an instance is already running makes the second process die with SIGSEGV (exit 139) about a second after start. Reproduced deterministically on Arch/Python 3.14; the issue has the symbolized stacks.

### The problem

`Gtk.Application` only finds out it is redundant once `run()` registers it on the session bus. By that point `Controller.get()` has already started the asyncio executor and the Rust local agent's tokio runtime. `run()` then returns immediately, `sys.exit()` begins `Py_Finalize()`, and the tokio workers are still calling into CPython while the interpreter is being torn down:

```
tokio worker                             main thread
PyObject_GetAttr                         _Py_Finalize
 _PyObject_GenericGetAttrWithDict         finalize_interp_delete
  _PyType_LookupStackRefAndVersion         PyInterpreterState_Delete
   Py_DECREF(op=0x0)                        _PyInterpreterState_FinalizeAllocatedBlocks
    _Py_IsImmortal(op=0x0)  <- SIGSEGV       (freeing the pymalloc arenas)
```

The app's own log shows the ordering — the local agent reports `Connected` about 10 ms *before* the `Gtk.Application` object is even constructed, let alone registered.

### The change

Check whether the application ID is already owned before building the controller, and if so hand over with `org.gtk.Application.Activate` and return. A redundant instance then never starts the async/Rust machinery at all — which also stops it opening a pointless local-agent session against the server on its way to dying.

Only the no-arguments case is short-circuited, so `--version` (which needs the controller) and `--start-minimized` keep going through `Gtk.Application`'s own option handling. The desktop entry is a bare `Exec=protonvpn-app`, so this covers the path users actually hit. If the probe fails for any reason it falls through to the existing behaviour.

### Note on scope

This is deliberately minimal so it is easy to review and backport. The more thorough fix is to defer constructing the `Controller` until `do_activate()` / `do_startup()`, so *no* early-exit path can leave the tokio runtime racing finalization — happy to rework it that way if you'd prefer. Independently, joining the local-agent runtime on shutdown would close the underlying unsafety for good.

### Testing

- Verified `NameHasOwner` + `Activate` against a running instance: the existing window is presented and the second process exits 0.
- Before: second launch reliably SIGSEGVs and dumps core. After: exits cleanly.
- `--version` and `--start-minimized` still take the normal path.