### PR TITLE
fix: re-register the tray icon when the StatusNotifierWatcher restarts

### DIFF
--- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
+++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
@@ -248,8 +248,9 @@ class _StatusNotifierItem(dbus.service.Object):
         # Create DBusMenu
         self.menu = _DBusMenuService(bus, tray_icon.menu_items)
 
-        # Register with watcher
+        # Register with watcher, and again if the watcher is restarted
         self._register_to_watcher()
+        self._watch_for_watcher_restarts()
 
     def _register_to_watcher(self):
         """Register with StatusNotifierWatcher"""
@@ -267,6 +268,47 @@ class _StatusNotifierItem(dbus.service.Object):
                 category="TRAY_ICON",
                 event="STATUS_NOTIFIER_WATCHER_REGISTRATION_FAILED",
             )
+
+    def _watch_for_watcher_restarts(self):
+        """Register again whenever a new StatusNotifierWatcher appears.
+
+        The watcher is owned by the desktop shell or panel, which can restart on
+        its own: Quickshell, Waybar, plasmashell, a GNOME extension host
+        reloading. A newly started watcher begins with an empty registry, so an
+        item that registers only once silently loses its icon until the whole
+        application is restarted.
+        """
+        # The spec puts this on the item: it should watch the bus and register
+        # whenever the watcher becomes available, not only at startup. See
+        # https://specifications.freedesktop.org/status-notifier-item-spec/status-notifier-item-spec-latest.html#registration  # pylint: disable=line-too-long # noqa: E501
+        try:
+            self.bus.add_signal_receiver(
+                self._on_watcher_name_owner_changed,
+                signal_name="NameOwnerChanged",
+                dbus_interface="org.freedesktop.DBus",
+                bus_name="org.freedesktop.DBus",
+                path="/org/freedesktop/DBus",
+                arg0=SNW_BUS_NAME,
+            )
+        except dbus.exceptions.DBusException:
+            logger.warning(
+                "Failed to watch StatusNotifierWatcher name ownership",
+                category="TRAY_ICON",
+                event="STATUS_NOTIFIER_WATCHER_WATCH_FAILED",
+            )
+
+    def _on_watcher_name_owner_changed(self, _name, _old_owner, new_owner):
+        """Re-register the item when a new watcher takes the name."""
+        if not new_owner:
+            # The watcher went away; nothing to do until a new one shows up.
+            return
+
+        logger.info(
+            "StatusNotifierWatcher reappeared, registering tray icon again",
+            category="TRAY_ICON",
+            event="STATUS_NOTIFIER_WATCHER_REREGISTERING",
+        )
+        self._register_to_watcher()
 
     @dbus.service.method(
         dbus_interface="org.freedesktop.DBus.Properties",


### PR DESCRIPTION
The tray icon disappears permanently whenever the desktop shell or panel restarts, and only comes back if the whole app is restarted. Reported as context in #187 — it is the reason users reach for the relaunch that crashes.

### The problem

`_StatusNotifierItem` calls `RegisterStatusNotifierItem` exactly once, from `setup()` (`tray_icon.py:252`). There is no `NameOwnerChanged` subscription for `org.kde.StatusNotifierWatcher` anywhere in the app.

The watcher is owned by whatever provides system-tray support, and that component restarts routinely — Quickshell, Waybar, plasmashell, a GNOME extension host reloading. A newly started watcher begins with an empty registry, so an item that registered only once is simply forgotten.

Observed on Arch (Hyprland + Quickshell), with the app still running the whole time:

```
13:36:45  protonvpn-app registers its item with watcher pid 17570
19:38:37  the shell exits; a new one starts a fresh watcher with an empty registry
```

```
$ busctl --user list | grep StatusNotifier
org.kde.StatusNotifierWatcher                        109922 quickshell
org.kde.StatusNotifierItem-proton.vpn.app.gtk-45745   45745 protonvpn-app

$ busctl --user get-property org.kde.StatusNotifierWatcher /StatusNotifierWatcher \
      org.kde.StatusNotifierWatcher RegisteredStatusNotifierItems
as 1 ":1.508/StatusNotifierItem"      # a different app; Proton VPN is absent
```

The item still owns its bus name, but the live watcher has no idea it exists, so nothing is drawn.

### The change

Subscribe to `NameOwnerChanged` filtered on the watcher's name, and call the existing `_register_to_watcher()` again whenever a new owner takes it. The [spec's registration section](https://specifications.freedesktop.org/status-notifier-item-spec/status-notifier-item-spec-latest.html#registration) puts this on the item — it should monitor the bus and register whenever the watcher becomes available, not only at startup. `libayatana-appindicator` does this for you; this hand-rolled `dbus-python` implementation did not.

Failures to install the watch are logged and ignored, matching how the existing registration failure is handled.

### Testing

- Confirmed the receiver fires on both appearance and disappearance of the watched name, and that only a non-empty `new_owner` triggers re-registration.
- Confirmed the repair itself is sufficient: calling `RegisterStatusNotifierItem` on the live watcher for the already-running app's existing item makes the icon come straight back, with no restart.