### PR TITLE
Update fr.po

### DIFF
--- a/proton/vpn/app/gtk/locale/fr.po
+++ b/proton/vpn/app/gtk/locale/fr.po
@@ -41,7 +41,7 @@ msgstr "Désactiver"
 
 msgctxt "button"
 msgid "Disconnect"
-msgstr "Déconnecté"
+msgstr "Déconnecter"
 
 msgctxt "button"
 msgid "Done"


### PR DESCRIPTION
Current translation in French for the Disconnect button is "Déconnecté" which literally translate as "Disconnected". This fixes the mistake to "Déconnecter" which is the proper translation.